### PR TITLE
Limit the size of the sending file

### DIFF
--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -353,9 +353,9 @@ export class PuppetWeb extends Puppet {
       }))
     })
 
-    let fileMaxSize = 20 * 1024 * 1024
-    if (buffer.length > fileMaxSize)
-      throw new Error('Maximum file size 20M')
+    const videoMaxSize = 20 * 1024 * 1024
+    if (mediatype == 'video' && buffer.length > videoMaxSize)
+      throw new Error('Sending video files is not allowed to exceed 20MB')
 
     let md5 = UtilLib.md5(buffer)
 

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -357,7 +357,7 @@ export class PuppetWeb extends Puppet {
     // https://github.com/Chatie/webwx-app-tracker/blob/7c59d35c6ea0cff38426a4c5c912a086c4c512b2/formatted/webwxApp.js#L1115
     const videoMaxSize = 20 * 1024 * 1024
     if (mediatype === 'video' && buffer.length > videoMaxSize)
-      throw new Error(`Sending video files is not allowed to exceed ${videoMaxSize/1024/1024}MB`)
+      throw new Error(`Sending video files is not allowed to exceed ${videoMaxSize / 1024 / 1024}MB`)
 
     let md5 = UtilLib.md5(buffer)
 

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -353,6 +353,10 @@ export class PuppetWeb extends Puppet {
       }))
     })
 
+    let fileMaxSize = 20 * 1024 * 1024
+    if (buffer.length > fileMaxSize)
+      throw new Error('Maximum file size 20M')
+
     let md5 = UtilLib.md5(buffer)
 
     let baseRequest = await this.getBaseRequest()

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -354,10 +354,10 @@ export class PuppetWeb extends Puppet {
     })
 
     // Sending video files is not allowed to exceed 20MB
-    // https://github.com/Chatie/webwx-app-tracker/blob/master/formatted/webwxApp.js#L1115
+    // https://github.com/Chatie/webwx-app-tracker/blob/7c59d35c6ea0cff38426a4c5c912a086c4c512b2/formatted/webwxApp.js#L1115
     const videoMaxSize = 20 * 1024 * 1024
     if (mediatype === 'video' && buffer.length > videoMaxSize)
-      throw new Error('Sending video files is not allowed to exceed 20MB')
+      throw new Error(`Sending video files is not allowed to exceed ${videoMaxSize/1024/1024}MB`)
 
     let md5 = UtilLib.md5(buffer)
 

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -353,6 +353,8 @@ export class PuppetWeb extends Puppet {
       }))
     })
 
+    //Sending video files is not allowed to exceed 20MB
+    //https://github.com/Chatie/webwx-app-tracker/blob/master/formatted/webwxApp.js#L1115
     const videoMaxSize = 20 * 1024 * 1024
     if (mediatype == 'video' && buffer.length > videoMaxSize)
       throw new Error('Sending video files is not allowed to exceed 20MB')

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -353,10 +353,10 @@ export class PuppetWeb extends Puppet {
       }))
     })
 
-    //Sending video files is not allowed to exceed 20MB
-    //https://github.com/Chatie/webwx-app-tracker/blob/master/formatted/webwxApp.js#L1115
+    // Sending video files is not allowed to exceed 20MB
+    // https://github.com/Chatie/webwx-app-tracker/blob/master/formatted/webwxApp.js#L1115
     const videoMaxSize = 20 * 1024 * 1024
-    if (mediatype == 'video' && buffer.length > videoMaxSize)
+    if (mediatype === 'video' && buffer.length > videoMaxSize)
       throw new Error('Sending video files is not allowed to exceed 20MB')
 
     let md5 = UtilLib.md5(buffer)


### PR DESCRIPTION
Wechat web limits the file size to 20M