### PR TITLE
fix jsdoc flush issue #378 and minor fix on the doc examples

### DIFF
--- a/src/contact.ts
+++ b/src/contact.ts
@@ -428,7 +428,7 @@ export class Contact implements Sayable {
   }
 
   /**
-   * Get the alias for contact
+   * GET the alias for contact
    *
    * @returns {(string | null)}
    *
@@ -440,7 +440,7 @@ export class Contact implements Sayable {
   public alias(): string | null
 
   /**
-   * Set the alias for contact
+   * SET the alias for contact
    *
    * tests show it will failed if set alias too frequently(60 times in one minute).
    *
@@ -460,7 +460,7 @@ export class Contact implements Sayable {
   public alias(newAlias: string): Promise<boolean>
 
   /**
-   * Delete the alias for a contact
+   * DELETE the alias for a contact
    *
    * @param {null} empty
    * @returns {Promise<boolean>}

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -485,7 +485,12 @@ export class Contact implements Sayable {
    *
    * @example GET the alias for a contact
    * ```ts
-   * const alias = contact.alias()  //@returns {(string | null)}
+   * const alias = contact.alias()
+   * if (alias === null) {
+   *   console.log('You have not yet set any alias for contact ' + contact.name())
+   * } else {
+   *   console.log('You have already set an alias for contact ' + contact.name() + ':' + alias)
+   * }
    * ```
    *
    * @example SET the alias for a contact

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -440,7 +440,7 @@ export class Contact implements Sayable {
   public alias(): string | null
 
   /**
-   * set the alias for contact
+   * Set the alias for contact
    *
    * tests show it will failed if set alias too frequently(60 times in one minute).
    *

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -469,9 +469,9 @@ export class Contact implements Sayable {
    * ```ts
    * const ret = await contact.alias(null)
    * if (ret) {
-   *   console.log('ok!')
+   *   console.log(`delete ${contact.name()}'s alias successfully!`)
    * } else {
-   *   console.error('fail!')
+   *   console.log(`failed to delete ${contact.name()}'s alias!`)
    * }
    * ```
    */
@@ -507,9 +507,9 @@ export class Contact implements Sayable {
    * ```ts
    * const ret = await contact.alias(null)
    * if (ret) {
-   *   console.log('ok!')
+   *   console.log(`delete ${contact.name()}'s alias successfully!`)
    * } else {
-   *   console.error('fail!')
+   *   console.log(`failed to delete ${contact.name()}'s alias!`)
    * }
    * ```
    */

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -477,6 +477,37 @@ export class Contact implements Sayable {
    */
   public alias(empty: null): Promise<boolean>
 
+  /**
+   * GET / SET / DELETE the alias for a contact
+   *
+   * @param {(none | string | null)} newAlias , 
+   * @returns {(string | null | Promise<boolean>)}
+   *
+   * @example GET the alias for a contact
+   * ```ts
+   * const alias = contact.alias()  //@returns {(string | null)}
+   * ```
+   * 
+   * @example SET the alias for a contact
+   * ```ts
+   * const ret = await contact.alias('lijiarui')  //@returns {Promise<boolean>}
+   * if (ret) {
+   *   console.log(`change ${contact.name()}'s alias successfully!`)
+   * } else {
+   *   console.error('failed to change ${contact.name()}'s alias!')
+   * }
+   * ```
+   * 
+   * @example DELETE the alias for a contact
+   * ```ts
+   * const ret = await contact.alias(null)  //@returns {Promise<boolean>}
+   * if (ret) {
+   *   console.log('ok!')
+   * } else {
+   *   console.error('fail!')
+   * }
+   * ```
+   */
   public alias(newAlias?: string|null): Promise<boolean> | string | null {
     log.silly('Contact', 'alias(%s)', newAlias || '')
 

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -480,14 +480,14 @@ export class Contact implements Sayable {
   /**
    * GET / SET / DELETE the alias for a contact
    *
-   * @param {(none | string | null)} newAlias , 
+   * @param {(none | string | null)} newAlias ,
    * @returns {(string | null | Promise<boolean>)}
    *
    * @example GET the alias for a contact
    * ```ts
    * const alias = contact.alias()  //@returns {(string | null)}
    * ```
-   * 
+   *
    * @example SET the alias for a contact
    * ```ts
    * const ret = await contact.alias('lijiarui')  //@returns {Promise<boolean>}
@@ -497,7 +497,7 @@ export class Contact implements Sayable {
    *   console.error('failed to change ${contact.name()}'s alias!')
    * }
    * ```
-   * 
+   *
    * @example DELETE the alias for a contact
    * ```ts
    * const ret = await contact.alias(null)  //@returns {Promise<boolean>}

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -449,7 +449,7 @@ export class Contact implements Sayable {
    *
    * @example
    * ```ts
-   * const ret = await contact.remark('lijiarui')
+   * const ret = await contact.alias('lijiarui')
    * if (ret) {
    *   console.log(`change ${contact.name()}'s alias successfully!`)
    * } else {
@@ -467,7 +467,7 @@ export class Contact implements Sayable {
    *
    * @example
    * ```ts
-   * const ret = await contact.remark(null)
+   * const ret = await contact.alias(null)
    * if (ret) {
    *   console.log('ok!')
    * } else {

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -490,7 +490,7 @@ export class Contact implements Sayable {
    *
    * @example SET the alias for a contact
    * ```ts
-   * const ret = await contact.alias('lijiarui')  //@returns {Promise<boolean>}
+   * const ret = await contact.alias('lijiarui')
    * if (ret) {
    *   console.log(`change ${contact.name()}'s alias successfully!`)
    * } else {
@@ -500,7 +500,7 @@ export class Contact implements Sayable {
    *
    * @example DELETE the alias for a contact
    * ```ts
-   * const ret = await contact.alias(null)  //@returns {Promise<boolean>}
+   * const ret = await contact.alias(null)
    * if (ret) {
    *   console.log('ok!')
    * } else {

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -353,6 +353,12 @@ export class PuppetWeb extends Puppet {
       }))
     })
 
+    // Sending video files is not allowed to exceed 20MB
+    // https://github.com/Chatie/webwx-app-tracker/blob/7c59d35c6ea0cff38426a4c5c912a086c4c512b2/formatted/webwxApp.js#L1115
+    const videoMaxSize = 20 * 1024 * 1024
+    if (mediatype === 'video' && buffer.length > videoMaxSize)
+      throw new Error(`Sending video files is not allowed to exceed ${videoMaxSize / 1024 / 1024}MB`)
+
     let md5 = UtilLib.md5(buffer)
 
     let baseRequest = await this.getBaseRequest()

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -353,12 +353,6 @@ export class PuppetWeb extends Puppet {
       }))
     })
 
-    // Sending video files is not allowed to exceed 20MB
-    // https://github.com/Chatie/webwx-app-tracker/blob/7c59d35c6ea0cff38426a4c5c912a086c4c512b2/formatted/webwxApp.js#L1115
-    const videoMaxSize = 20 * 1024 * 1024
-    if (mediatype === 'video' && buffer.length > videoMaxSize)
-      throw new Error(`Sending video files is not allowed to exceed ${videoMaxSize / 1024 / 1024}MB`)
-
     let md5 = UtilLib.md5(buffer)
 
     let baseRequest = await this.getBaseRequest()


### PR DESCRIPTION
#378 I have fixed this flush issue! 

And also, I made 2 minor fix: 
* Fix 'set' => 'Set' of upper case.  
* Fix examples on contact.alias() function.  User '.alias()' instead of '.remark // should be deprecated '