### PR TITLE
Fix chrome driver path problem in Windows

### DIFF
--- a/src/puppet-web/browser-driver.ts
+++ b/src/puppet-web/browser-driver.ts
@@ -81,6 +81,8 @@ export class BrowserDriver {
     }
    */
 
+    require('chromedriver')
+
     const options = {
       args: [
         '--homepage=about:blank',

--- a/src/puppet-web/browser-driver.ts
+++ b/src/puppet-web/browser-driver.ts
@@ -81,14 +81,6 @@ export class BrowserDriver {
     }
    */
 
-    /**
-     * https://github.com/Chatie/wechaty/pull/416
-     * In some circumstances, ChromeDriver could not be found on the current PATH.
-     * The chromedriver package always adds directory of chrome driver binary to PATH.
-     * So we requires chromedriver here to avoid PATH issue.
-     */
-    require('chromedriver')
-
     const options = {
       args: [
         '--homepage=about:blank',
@@ -98,6 +90,14 @@ export class BrowserDriver {
     if (Config.isDocker) {
       log.verbose('PuppetWebBrowserDriver', 'initChromeDriver() wechaty in docker confirmed(should not show this in CI)')
       options['binary'] = Config.CMD_CHROMIUM
+    } else {
+      /**
+       * https://github.com/Chatie/wechaty/pull/416
+       * In some circumstances, ChromeDriver could not be found on the current PATH when not in Docker.
+       * The chromedriver package always adds directory of chrome driver binary to PATH.
+       * So we requires chromedriver here to avoid PATH issue.
+       */
+      require('chromedriver')
     }
 
     const customChrome = Capabilities.chrome()

--- a/src/puppet-web/browser-driver.ts
+++ b/src/puppet-web/browser-driver.ts
@@ -81,6 +81,12 @@ export class BrowserDriver {
     }
    */
 
+    /**
+     * https://github.com/Chatie/wechaty/pull/416
+     * In some circumstances, ChromeDriver could not be found on the current PATH.
+     * The chromedriver package always adds directory of chrome driver binary to PATH.
+     * So we requires chromedriver here to avoid PATH issue.
+     */
     require('chromedriver')
 
     const options = {


### PR DESCRIPTION
After install from souce in Windows, `npm run demo` throws:
```
21:13:29 ERR PuppetWebBrowserDriver initChromeDriver() Wechaty require `chromedriver` to be installed.(try to run: "npm
install chromedriver" to fix this issue)
21:13:29 ERR PuppetWebBrowser init() exception: The ChromeDriver could not be found on the current PATH. Please download
 the latest version of the ChromeDriver from http://chromedriver.storage.googleapis.com/index.html and ensure it can be
found on your PATH.
```

I solved the problem in following steps:
1. Check if `chromedriver` installed correctly: these is no error when `npm install` and `PROJECT_ROOT\node_modules\chromedriver\lib\chromedriver\chromedriver.exe` exists.
2. Check if PATH wrong: `npm run demo` succeeded if adding `PROJECT_ROOT\node_modules\chromedriver\lib\chromedriver` dir to PATH env and failed if removing `PROJECT_ROOT\node_modules\chromedriver\lib\chromedriver` dir from PATH env.

So i am sure the problem is related to `PATH` im my circumstance. After some search, I found that https://www.npmjs.com/package/chromedriver#running-with-selenium-webdriver.
When `require('chromedriver')`, it will do https://github.com/giggio/node-chromedriver/blob/master/lib/chromedriver.js#L2. So `PATH` problem solved.