### PR TITLE
fix #512

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -448,8 +448,8 @@ export class Message implements Sayable {
 
     if (atList.length === 0) return contactList
 
-    // Using `filter(e => e.indexOf('@') > -1)` to filter the string without `@`
     let mentionList: string[] = []
+    // atList here is trying to fill in mentionList in function multipulAt()
     atList
       .filter(str => str.includes('@'))
       .map(str => multipleAt(str))
@@ -474,8 +474,8 @@ export class Message implements Sayable {
     log.verbose('Message', 'mentioned(%s),get mentionList: %s', this.content(), JSON.stringify(mentionList))
 
     mentionList.map(nameStr => {
-      const nameStrList = room.memberAll(nameStr)
-      contactList = contactList.concat(nameStrList || [])
+      const nameList = room.memberAll(nameStr)
+      contactList = contactList.concat(nameList || [])
     })
 
     if (contactList.length === 0) {

--- a/src/message.ts
+++ b/src/message.ts
@@ -448,13 +448,14 @@ export class Message implements Sayable {
 
     if (atList.length === 0) return contactList
 
-    let mentionList: string[] = []
     // atList here is trying to fill in mentionList in function multipulAt()
-    atList
+    const rawMentionedList = atList
       .filter(str => str.includes('@'))
-      .map(str => {
-        mentionList = mentionList.concat(multipleAt(str) || [])
-      })
+      .map(str => multipleAt(str) )
+
+    // flatten array, see http://stackoverflow.com/a/10865042/1123955
+    const mentionList = [].concat.apply([], rawMentionedList)
+    log.verbose('Message', 'mentioned(%s),get mentionList: %s', this.content(), JSON.stringify(mentionList))
 
     // convert 'hello@a@b@c' to [ 'c', 'b@c', 'a@b@c' ]
     function multipleAt(str: string) {

--- a/src/message.ts
+++ b/src/message.ts
@@ -479,7 +479,7 @@ export class Message implements Sayable {
     })
 
     if (contactList.length === 0) {
-      log.warn(`Message`, `message.mentioned() can not found member using room.member() from mentionList, metion string: ${JSON.stringify(mentionList)}`)
+      log.warn(`Message`, `message.mentioned() can not found member using room.member() from mentionList, mention string: ${JSON.stringify(mentionList)}`)
     }
     return contactList
   }

--- a/src/message.ts
+++ b/src/message.ts
@@ -441,8 +441,8 @@ export class Message implements Sayable {
       return contactList
     }
 
-    // define magic code `8197` to identify @xxx now it is 32(normal blank)
-    const AT_SEPRATOR = String.fromCharCode(32)
+    // define magic code `8197` to identify @xxx (wechat version > 6.5, old version use normal blank `32`)
+    const AT_SEPRATOR = String.fromCharCode(8197)
 
     const atList = this.content().split(AT_SEPRATOR)
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -452,10 +452,11 @@ export class Message implements Sayable {
     // atList here is trying to fill in mentionList in function multipulAt()
     atList
       .filter(str => str.includes('@'))
-      .map(str => multipleAt(str))
-      .filter(str => !!str) // filter blank string
+      .map(str => {
+        mentionList = mentionList.concat(multipleAt(str) || [])
+      })
 
-    // convert 'hello@a@b@c' to [ 'c', 'b@c', 'a@b@c' ] and integrate all possible strings to mentionList
+    // convert 'hello@a@b@c' to [ 'c', 'b@c', 'a@b@c' ]
     function multipleAt(str: string) {
       str = str.replace(/^.*?@/, '@')
         let name = ''
@@ -467,8 +468,7 @@ export class Message implements Sayable {
             name = mentionName + '@' + name
             nameList.push(name.slice(0, -1)) // get rid of the `@` at beginning
           })
-        mentionList = mentionList.concat(nameList || [])
-        return mentionList
+        return nameList
     }
 
     log.verbose('Message', 'mentioned(%s),get mentionList: %s', this.content(), JSON.stringify(mentionList))


### PR DESCRIPTION
#512 

@JasLin  I found after web wechat update its code by [webwx-8a1ea56](https://github.com/Chatie/webwx-app-tracker/commit/1b69b89c02f8d8614247c09bfd3a96934068b08c) and [webwx-40649b7](https://github.com/Chatie/webwx-app-tracker/commit/fd3f24b16fad86e40c2ba6ea1ff7e1ce8b75fe1a) we cannot identify real `@` by magic code `8197` but normal blank `32`

Please help to check my guess.

Using the following code:
```ts
.on('message', async function(m){
  const content = m.content()
  for (let i = 0; i < content.length; i ++) {
    console.log('[' + content[i] + ']的编码为:' + content.charCodeAt(i))
  }
})
```
## New version wechat(>=6.5)

### When I just mention **wuli舞哩客服** with  `@wuli舞哩客服`

Log as follows， we cannot get a magic code(8197)
```
[@]的编码为:64
[w]的编码为:119
[u]的编码为:117
[l]的编码为:108
[i]的编码为:105
[舞]的编码为:33310
[哩]的编码为:21737
[客]的编码为:23458
[服]的编码为:26381
[ ]的编码为:8197
```

### When I mention **wuli舞哩客服** and say hi using `@wuli舞哩客服 hi`

Log as follows， we can get a magic code(8197) between `@wuli舞哩客服` and `hi`
```
[@]的编码为:64
[w]的编码为:119
[u]的编码为:117
[l]的编码为:108
[i]的编码为:105
[舞]的编码为:33310
[哩]的编码为:21737
[客]的编码为:23458
[服]的编码为:26381
[ ]的编码为:8197
[h]的编码为:104
[i]的编码为:105
```

## Old version wechat(<=6.3)

### When I just mention **wuli舞哩客服** with  `@wuli舞哩客服`

Log as follows， we cannot get a normal blank(32)
```
[@]的编码为:64
[w]的编码为:119
[u]的编码为:117
[l]的编码为:108
[i]的编码为:105
[舞]的编码为:33310
[哩]的编码为:21737
[客]的编码为:23458
[服]的编码为:26381
```
### When I mention **wuli舞哩客服** and say hi using `@wuli舞哩客服 hi`

Log as follows， we can get a normal blank(32) between `@wuli舞哩客服` and `hi`
```
[@]的编码为:64
[w]的编码为:119
[u]的编码为:117
[l]的编码为:108
[i]的编码为:105
[舞]的编码为:33310
[哩]的编码为:21737
[客]的编码为:23458
[服]的编码为:26381
[ ]的编码为:32
[h]的编码为:104
[i]的编码为:105
```

So I change the code as this pull request shows.

Btw, delete some flatten array bug and typo error.