### PR TITLE
room-join cannot detect inviteeList when people join in the room with qrcode

### DIFF
--- a/src/puppet-web/firer.spec.ts
+++ b/src/puppet-web/firer.spec.ts
@@ -88,7 +88,7 @@ test('parseRoomJoin()', t => {
     ],
     [
       `"桔小秘"通过扫描你分享的二维码加入群聊`,
-      undefined,
+      `你`,
       ['桔小秘'],
     ],
     [
@@ -98,7 +98,7 @@ test('parseRoomJoin()', t => {
     ],
     [
       `"桔小秘" joined the group chat via your shared QR Code.`,
-      undefined,
+      `your`,
       ['桔小秘'],
     ],
     [

--- a/src/puppet-web/firer.spec.ts
+++ b/src/puppet-web/firer.spec.ts
@@ -88,21 +88,21 @@ test('parseRoomJoin()', t => {
     ],
     [
       `"桔小秘"通过扫描你分享的二维码加入群聊`,
-      `你`,
+      undefined,
       ['桔小秘'],
     ],
     [
-      `"桔小秘"通过扫描"李佳芮"分享的二维码加入群聊`,
+      `" 桔小秘"通过扫描"李佳芮"分享的二维码加入群聊`,
       `李佳芮`,
       ['桔小秘'],
     ],
     [
       `"桔小秘" joined the group chat via your shared QR Code.`,
-      `your`,
+      undefined,
       ['桔小秘'],
     ],
     [
-      `"桔小秘" joined the group chat via the QR Code shared by "李佳芮".`,
+      `" 桔小秘" joined the group chat via the QR Code shared by "李佳芮".`,
       `李佳芮`,
       ['桔小秘'],
     ],

--- a/src/puppet-web/firer.spec.ts
+++ b/src/puppet-web/firer.spec.ts
@@ -97,12 +97,22 @@ test('parseRoomJoin()', t => {
       ['桔小秘'],
     ],
     [
+      `"桔小秘"通过扫描"李佳芮"分享的二维码加入群聊`,
+      `李佳芮`,
+      ['桔小秘'],
+    ],
+    [
       `"桔小秘" joined the group chat via your shared QR Code.`,
       `your`,
       ['桔小秘'],
     ],
     [
       `" 桔小秘" joined the group chat via the QR Code shared by "李佳芮".`,
+      `李佳芮`,
+      ['桔小秘'],
+    ],
+    [
+      `"桔小秘" joined the group chat via the QR Code shared by "李佳芮".`,
       `李佳芮`,
       ['桔小秘'],
     ],

--- a/src/puppet-web/firer.ts
+++ b/src/puppet-web/firer.ts
@@ -60,6 +60,7 @@ const regexConfig = {
 
   roomJoinQrcode: [
     /^" (.+)" joined the group chat via the QR Code shared by "?(.+?)".$/,
+    /^"(.+)" joined the group chat via the QR Code shared by "?(.+?)".$/,
     /^"(.+)" joined the group chat via "?(.+?)"? shared QR Code.$/,
     /^" (.+)"通过扫描"?(.+?)"?分享的二维码加入群聊$/,
     /^"(.+)"通过扫描"?(.+?)"?分享的二维码加入群聊$/,

--- a/src/puppet-web/firer.ts
+++ b/src/puppet-web/firer.ts
@@ -60,9 +60,9 @@ const regexConfig = {
 
   roomJoinQrcode: [
     /^" (.+)" joined the group chat via the QR Code shared by "?(.+?)".$/,
-    /^"(.+)" joined the group chat via your shared QR Code.$/,
+    /^"(.+)" joined the group chat via "?(.+?)"? shared QR Code.$/,
     /^" (.+)"通过扫描"?(.+?)"?分享的二维码加入群聊$/,
-    /^"(.+)"通过扫描你分享的二维码加入群聊$/,
+    /^"(.+)"通过扫描"?(.+?)"?分享的二维码加入群聊$/,
   ],
 
   // no list
@@ -195,9 +195,7 @@ async function checkRoomJoin(m: Message): Promise<void> {
   let inviteeContactList: Contact[] = []
 
   try {
-    // match reg `/^"(.+)"通过扫描你分享的二维码加入群聊$/,` or /^"(.+)" joined the group chat via your shared QR Code.$/,
-    // cannot get founder[2], then inviter here return undefined
-    if (!inviter) {
+    if (inviter === "You've" || inviter === '你' || inviter === 'your') {
       inviterContact = Contact.load(this.userId)
     }
 

--- a/src/puppet-web/firer.ts
+++ b/src/puppet-web/firer.ts
@@ -59,9 +59,10 @@ const regexConfig = {
   ],
 
   roomJoinQrcode: [
-    /^"(.+)" joined the group chat via the QR Code shared by "?(.+?)".$/,
-    /^"(.+)" joined the group chat via "?(.+?)"? shared QR Code.$/,
-    /^"(.+)"通过扫描"?(.+?)"?分享的二维码加入群聊$/,
+    /^" (.+)" joined the group chat via the QR Code shared by "?(.+?)".$/,
+    /^"(.+)" joined the group chat via your shared QR Code.$/,
+    /^" (.+)"通过扫描"?(.+?)"?分享的二维码加入群聊$/,
+    /^"(.+)"通过扫描你分享的二维码加入群聊$/,
   ],
 
   // no list
@@ -194,7 +195,9 @@ async function checkRoomJoin(m: Message): Promise<void> {
   let inviteeContactList: Contact[] = []
 
   try {
-    if (inviter === "You've" || inviter === '你' || inviter === 'your') {
+    // match reg `/^"(.+)"通过扫描你分享的二维码加入群聊$/,` or /^"(.+)" joined the group chat via your shared QR Code.$/,
+    // cannot get founder[2], then inviter here return undefined
+    if (!inviter) {
       inviterContact = Contact.load(this.userId)
     }
 


### PR DESCRIPTION
room-join cannot detect inviteeList when people join in the room with QR code:

* If one contact joins in the room by the QR code shared by the bot, system message as follows:
   - "李佳芮" joined the group chat via your shared QR Code.
   - "李佳芮"通过扫描你分享的二维码加入群聊

* If one contact joins in the room isn't by the QRcode shared by the bot, system message as follows:
    - " 李佳芮" joined the group chat via your shared QR Code.
    - " 李佳芮"通过扫描你分享的二维码加入群聊
    (Pay attention that it has more space before 李佳芮)