### PR TITLE
fix(puppet-web): send any type file.

### DIFF
--- a/src/puppet-web/bridge.ts
+++ b/src/puppet-web/bridge.ts
@@ -397,15 +397,14 @@ export class Bridge {
     }
   }
 
-  public sendMedia(toUserName: string, mediaId: string, type: number): Promise<boolean> {
-    if (!toUserName) {
+  public sendMedia(mediaData: any): Promise<boolean> {
+    if (!mediaData.ToUserName) {
       throw new Error('UserName not found')
     }
-    if (!mediaId) {
+    if (!mediaData.MediaId) {
       throw new Error('cannot say nothing')
     }
-
-    return this.proxyWechaty('sendMedia', toUserName, mediaId, type)
+    return this.proxyWechaty('sendMedia', mediaData)
               .catch(e => {
                 log.error('PuppetWebBridge', 'sendMedia() exception: %s', e.message)
                 throw e

--- a/src/puppet-web/bridge.ts
+++ b/src/puppet-web/bridge.ts
@@ -23,6 +23,17 @@ import { log }    from '../config'
 
 import PuppetWeb  from './puppet-web'
 
+export interface MediaData {
+  ToUserName: string,
+  MsgType: number,
+  MediaId: string,
+  FileName: string,
+  FileSize: number,
+  FileMd5?: string,
+  MMFileId: string,
+  MMFileExt: string,
+}
+
 export class Bridge {
 
   constructor(
@@ -397,7 +408,7 @@ export class Bridge {
     }
   }
 
-  public sendMedia(mediaData: any): Promise<boolean> {
+  public sendMedia(mediaData: MediaData): Promise<boolean> {
     if (!mediaData.ToUserName) {
       throw new Error('UserName not found')
     }

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -410,8 +410,6 @@ export class PuppetWeb extends Puppet {
       FileMd5: md5,
       MMFileId: id,
       MMFileExt: ext,
-      // MMUploadProgress: 0,
-      // MMFileStatus: 1,
     }
 
     const formData = {

--- a/src/puppet-web/puppet-web.ts
+++ b/src/puppet-web/puppet-web.ts
@@ -417,11 +417,11 @@ export class PuppetWeb extends Puppet {
     }
 
     const formData = {
-      id: this.fileId,
+      id,
       name: filename,
       type: contentType,
       lastModifiedDate: Date().toString(),
-      size: size,
+      size,
       mediatype,
       uploadmediarequest: JSON.stringify(uploadMediaRequest),
       webwx_data_ticket: webwxDataTicket,

--- a/src/puppet-web/wechaty-bro.js
+++ b/src/puppet-web/wechaty-bro.js
@@ -492,7 +492,7 @@
         FileName: data.FileName,
         FileSize: data.FileSize,
         MMFileExt: data.MMFileExt,
-        MMFileId: data.MMFileId,
+        MMFileId: data.MMFileId
       }
 
       var m = chatFactory.createMessage(d)

--- a/src/puppet-web/wechaty-bro.js
+++ b/src/puppet-web/wechaty-bro.js
@@ -475,7 +475,7 @@
     return confFactory.API_webwxuploadmedia
   }
 
-  function sendMedia(ToUserName, MediaId,Type) {
+  function sendMedia(data) {
     var chatFactory = WechatyBro.glue.chatFactory
     var confFactory = WechatyBro.glue.confFactory
 
@@ -485,11 +485,19 @@
     }
 
     try {
-      var m = chatFactory.createMessage({
-        ToUserName: ToUserName
-        , MediaId: MediaId
-        , MsgType: Type
-      })
+      var d = {
+        ToUserName: data.ToUserName,
+        MediaId: data.MediaId,
+        MsgType: data.MsgType,
+        FileName: data.FileName,
+        FileMd5: data.FileMd5,
+        FileSize: data.FileSize,
+        FileType: data.FileType || 7,
+        MMFileExt: data.MMFileExt,
+        MMFileId: data.MMFileId,
+      }
+
+      var m = chatFactory.createMessage(d)
       chatFactory.appendMessage(m)
       chatFactory.sendMessage(m)
     } catch (e) {

--- a/src/puppet-web/wechaty-bro.js
+++ b/src/puppet-web/wechaty-bro.js
@@ -490,9 +490,7 @@
         MediaId: data.MediaId,
         MsgType: data.MsgType,
         FileName: data.FileName,
-        FileMd5: data.FileMd5,
         FileSize: data.FileSize,
-        FileType: data.FileType || 7,
         MMFileExt: data.MMFileExt,
         MMFileId: data.MMFileId,
       }


### PR DESCRIPTION
Fix can't send pdf and more type file.
Now, you can use `m.say(new MediaMessage(file))` send any type file.

Fix #710

