### PR TITLE
Fixed: replace `document.domain`  with `location.hostname` since front one sometimes lose subdomain name

### DIFF
--- a/src/puppet-web/browser.ts
+++ b/src/puppet-web/browser.ts
@@ -128,7 +128,7 @@ export class Browser extends EventEmitter {
 
   public async hostname(): Promise<string | null> {
     log.verbose('PuppetWebBrowser', 'hostname()')
-    const domain = await this.execute('return document.domain')
+    const domain = await this.execute('return location.hostname')
     log.silly('PuppetWebBrowser', 'hostname() got %s', domain)
     return domain
   }


### PR DESCRIPTION
![2017-08-30 11 42 18](https://user-images.githubusercontent.com/4012276/29854690-2f883112-8d7a-11e7-921f-c199a5d6ad9b.png)
