### PR TITLE
fix: fix vscode setting, and close autoFixOnSave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,20 +1,25 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib"
-  , "typescript.check.tscVersion": false
-  , "files.exclude": {
-      "dist/": true
-    , "doc/": true
-    , "node_modules/": true
-    , "package/": true
-  }
-  , "alignment": {
-        "operatorPadding": "right"
-      , "indentBase":      "firstline"
-      , "surroundSpace":   {
-        "colon":      [-1, 1],   // The first number specify how much space to add to the left, can be negative. The second number is how much space to the right, can be negative.
-        "assignment": [1, 1],    // The same as above.
-        "arrow":      [1, 1],    // The same as above.
-        "comment":    2          // Special how much space to add between the trailing comment and the code.
-                               // If this value is negative, it means don't align the trailing comment.
+  "typescript.tsdk": "./node_modules/typescript/lib"
+, "typescript.check.tscVersion": false
+, "files.exclude": {
+    "dist/": true
+  , "doc/": true
+  , "node_modules/": true
+  , "package/": true
+}
+, "alignment": {
+      "operatorPadding": "right"
+    , "indentBase":      "firstline"
+    , "surroundSpace":   {
+      "colon":      [-1, 1],   // The first number specify how much space to add to the left, can be negative. The second number is how much space to the right, can be negative.
+      "assignment": [1, 1],    // The same as above.
+      "arrow":      [1, 1],    // The same as above.
+      "comment":    2          // Special how much space to add between the trailing comment and the code.
+                             // If this value is negative, it means don't align the trailing comment.
     }
+  }
+  , "eslint.autoFixOnSave": false
+  , "tslint.autoFixOnSave": false
+  , "editor.formatOnSave": false
+  , "typescript.extension.sortImports.sortOnSave": false
 }


### PR DESCRIPTION
fix #843 

add some setting to close autoFixOnSave, to avoid the automatic formatting of the plug-in code format changes too much.
```
  , "eslint.autoFixOnSave": false
  , "tslint.autoFixOnSave": false
  , "editor.formatOnSave": false
  , "typescript.extension.sortImports.sortOnSave": false
```