### PR TITLE
added TZ to set timezone for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:17.10
 LABEL maintainer="Huan LI <zixia@zixia.net>"
 
 ENV DEBIAN_FRONTEND     noninteractive
+ENV TZ                  Etc/UTC
 ENV WECHATY_DOCKER      1
 ENV LC_ALL              C.UTF-8
 ENV NODE_ENV            $NODE_ENV
@@ -30,6 +31,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
   && apt-get purge --auto-remove \
   && rm -rf /tmp/* /var/lib/apt/lists/*
+  
+# Set timezone for container
+RUN echo $TZ > /etc/timezone && \ rm /etc/localtime && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get update && apt-get install -y --no-install-recommends nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /tmp/* /var/lib/apt/lists/*
   
 # Set timezone for container
-RUN echo $TZ > /etc/timezone && \ rm /etc/localtime && \
+RUN echo $TZ > /etc/timezone && \ 
+    rm /etc/localtime && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata
 


### PR DESCRIPTION
```
$ docker run -d --volume="$(pwd)":/bot -e TZ=Asia/Shanghai zixia/wechaty index.js
```

The container default timezone is "Etc/UTC". when I was using wechaty to do some time base scheduled works I have to calculate the timezone differences.


