### PR TITLE
fail to install node dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ $ docker run -ti --rm --volume="$(pwd)":/bot zixia/wechaty mybot.ts # for TypeSc
 [![Greenkeeper badge](https://badges.greenkeeper.io/Chatie/wechaty.svg)](https://greenkeeper.io/)
 
 ```shell
+$ npm init
 $ npm install wechaty
 
 $ cat > mybot.js <<'_EOF_'
@@ -113,7 +114,6 @@ const bot = Wechaty.instance()
 console.log(bot.version())
 _EOF_
 
-$ npm init
 $ node mybot.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ const bot = Wechaty.instance()
 console.log(bot.version())
 _EOF_
 
+$ npm init
 $ node mybot.js
 ```
 


### PR DESCRIPTION
before you run `mybot.js` make sure you have `package.json` along with the script，or it would fail to install dependencies

```
➜  npm install wechaty

> puppeteer@0.13.0 install /Users/hiwanz/test/node_modules/puppeteer
> node install.js

ERROR: Failed to download Chromium r515411! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download.
{ Error: read ETIMEDOUT
    at _errnoException (util.js:1024:11)
    at TLSWrap.onread (net.js:615:25) code: 'ETIMEDOUT', errno: 'ETIMEDOUT', syscall: 'read' }
npm WARN enoent ENOENT: no such file or directory, open '/Users/hiwanz/test/package.json'
npm WARN test No description
npm WARN test No repository field.
npm WARN test No README data
npm WARN test No license field.

```