### PR TITLE
check room valid by id

### DIFF
--- a/src/puppet-padchat/padchat-rpc.ts
+++ b/src/puppet-padchat/padchat-rpc.ts
@@ -722,6 +722,15 @@ export class PadchatRpc extends EventEmitter {
       return null
     }
 
+    /**
+     * Bot quit the room, no roomId
+     * See: https://github.com/lijiarui/wechaty-puppet-padchat/issues/38
+     * {"chatroom_id":0,"count":0,"member":"null\n","message":"","status":0,"user_name":""}
+     */
+    if (result.count === 0) {
+      return null
+    }
+
     log.silly('PadchatRpc', 'WXGetChatRoomMember() result: %s', JSON.stringify(result).substr(0, 500))
 
     // 00:40:44 SILL PadchatRpc WXGetChatRoomMember() result: {"chatroom_id":0,"count":0,"member":"null\n","message":"","status":0,"user_name":""}


### PR DESCRIPTION
#1345 

This is because when bot quit the room, room data still in cache. We should call `WXGetChatRoomMember(roomId: string)` to check whether chatroom still valid. See more data in : https://github.com/lijiarui/wechaty-puppet-padchat/issues/38