### PR TITLE
add await for promise

### DIFF
--- a/src/puppet-padchat/padchat-manager.ts
+++ b/src/puppet-padchat/padchat-manager.ts
@@ -497,7 +497,7 @@ export class PadchatManager extends PadchatRpc {
        * 1.1 Delete token for prevent future useless auto login retry
        */
       delete deviceInfo.token
-      this.options.memory.set(MEMORY_SLOT_NAME, memorySlot)
+      await this.options.memory.set(MEMORY_SLOT_NAME, memorySlot)
       await this.options.memory.save()
 
       await this.emitLoginQrcode()
@@ -532,7 +532,7 @@ export class PadchatManager extends PadchatRpc {
      * 5 Delete token for prevent future useless auto login retry
      */
     delete deviceInfo.token
-    this.options.memory.set(MEMORY_SLOT_NAME, memorySlot)
+    await this.options.memory.set(MEMORY_SLOT_NAME, memorySlot)
     await this.options.memory.save()
 
     return false
@@ -855,7 +855,7 @@ export class PadchatManager extends PadchatRpc {
              * Use delay queue executor to sync room:
              *  add syncRoomMember task to the queue
              */
-            this.delayQueueExecutor.execute(
+            await this.delayQueueExecutor.execute(
               () => this.syncRoomMember(roomId),
               `syncRoomMember(${roomId})`,
             )


### PR DESCRIPTION
Add `await` for promise function

See #1346 

When I run `npm run lint` It shows no error:

```shell
> wechaty@0.15.217 lint /Users/jiaruili/git/rui/wechaty
> npm run check-node-version && npm run lint:ts && npm run lint:es && npm run lint:sh


> wechaty@0.15.217 check-node-version /Users/jiaruili/git/rui/wechaty
> check-node-version --node ">= 8.5"


> wechaty@0.15.217 lint:ts /Users/jiaruili/git/rui/wechaty
> tslint --project tsconfig.json && tsc --noEmit


> wechaty@0.15.217 lint:es /Users/jiaruili/git/rui/wechaty
> eslint "{bin,examples,scripts,src,tests}/**/*.js" --ignore-pattern="tests/fixtures/**"


> wechaty@0.15.217 lint:sh /Users/jiaruili/git/rui/wechaty
> bash -n bin/*.sh
```

But I find there lose some await in this pr.

It seems sometimes, `tslint` cannot work as expect, see more here:  https://github.com/lijiarui/xiaoju-bot/issues/20