### PR TITLE
mock self bot when WXGetContact() return null user_name

### DIFF
--- a/src/puppet-padchat/puppet-padchat.ts
+++ b/src/puppet-padchat/puppet-padchat.ts
@@ -65,6 +65,8 @@ import {
   roomJoinEventMessageParser,
   roomLeaveEventMessageParser,
   roomTopicEventMessageParser,
+
+  generateFakeSelfBot,
 }                                         from './pure-function-helpers'
 
 import {
@@ -684,10 +686,19 @@ export class PuppetPadchat extends Puppet {
   public async contactRawPayload(contactId: string): Promise<PadchatContactPayload> {
     log.silly('PuppetPadchat', 'contactRawPayload(%s)', contactId)
 
+    if (!this.id) {
+      throw Error('bot not login!')
+    }
+
     if (!this.padchatManager) {
       throw new Error('no padchat manager')
     }
     const rawPayload = await this.padchatManager.contactRawPayload(contactId)
+
+    if (!rawPayload.user_name && contactId === this.id) {
+      return generateFakeSelfBot(contactId)
+    }
+
     return rawPayload
   }
 

--- a/src/puppet-padchat/pure-function-helpers/compatible-wei-bug.ts
+++ b/src/puppet-padchat/pure-function-helpers/compatible-wei-bug.ts
@@ -12,9 +12,40 @@
  * BUG compitable: "\n\u00135907139882@chatroom" -> "5907139882@chatroom"
  * BUG compitable: "\n\u001412558026334@chatroom" -> "12558026334@chatroom"
  */
+
+import {
+  ContactGender,
+} from 'wechaty-puppet'
+
 export function stripBugChatroomId(id?: string) {
   if (!id) {
     return ''
   }
   return id.replace(/^\n[\u0000-\uffff]/g, '')
+}
+
+/**
+ * Sometimes, using WXGetContact(id) cannot get result,
+ * even if the id is bot it self
+ *
+ */
+export function generateFakeSelfBot(contactId: string) {
+  return {
+    big_head          : 'http://www.botorange.com',
+    city              : 'Chatie',
+    country           : 'BotOrange',
+    intro             : '',
+    label             : '',
+    nick_name         : 'default padchat',
+    provincia         : '',
+    py_initial        : '',
+    remark            : '',
+    remark_py_initial : '',
+    remark_quan_pin   : '',
+    sex               : ContactGender.Unknown,
+    signature         : 'welcome to BotOrange',
+    small_head        : 'www.botorange.com',
+    status            : 0,
+    user_name         : contactId,
+  }
 }


### PR DESCRIPTION
When WXGetContact(botid) cannot get user_name, I mock a fake bot info here, just a workaround way....