### PR TITLE
Bump wechaty-puppet-padchat version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "0.21.32",
+  "version": "0.22.0",
   "description": "Wechaty is a Bot SDK for Wechat Personal Account",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/puppet-config.ts
+++ b/src/puppet-config.ts
@@ -8,7 +8,7 @@ export const PUPPET_DEPENDENCIES = {
   // 'wechaty-puppet-hostie'    : '^0.0.1',
   'wechaty-puppet-ioscat'    : '^0.5.10',
   'wechaty-puppet-mock'      : '^0.14.1',
-  'wechaty-puppet-padchat'   : '^0.14.1',
+  'wechaty-puppet-padchat'   : '^0.16.1',
   'wechaty-puppet-puppeteer' : '^0.14.1',
   'wechaty-puppet-wechat4u'  : '^0.14.1',
 }


### PR DESCRIPTION
We are closing Beta testing in `wechaty-puppet-padchat`.

After update `wechaty-puppet-padchat` to `v0.16.1` or higher, we will switch to a new server. Old token will not be able to connect to the server. If you are a paid user, please contact us to get new ones. And please refer to this [migration guide](https://github.com/lijiarui/wechaty-puppet-padchat/wiki/Migration-guide-for-paid-user)

Versions earlier than v0.15.5 are still connecting to old server, which will still be running for 2 more weeks, and it will be closed on 09-12-2018. If you are running production service with old version, please prepare to do the migration.