### PR TITLE
fix: Message.mention()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -229,6 +229,8 @@ export function qrCodeForChatie (): FileBox {
 // http://jkorpela.fi/chars/spaces.html
 // String.fromCharCode(8197)
 export const FOUR_PER_EM_SPACE = String.fromCharCode(0x2005)
+// mobile: \u2005, PC、mac: \u0020
+export const AT_SEPRATOR_REGEX = /[\u2005\u0020]/
 
 export function qrcodeValueToImageUrl (qrcodeValue: string): string {
   return [

--- a/src/user/message.ts
+++ b/src/user/message.ts
@@ -33,7 +33,7 @@ import {
   Accessory,
 }                       from '../accessory'
 import {
-  FOUR_PER_EM_SPACE,
+  AT_SEPRATOR_REGEX,
   log,
   Raven,
 }                       from '../config'
@@ -599,7 +599,7 @@ export class Message extends Accessory implements Sayable {
 
     // define magic code `8197` to identify @xxx
     // const AT_SEPRATOR = String.fromCharCode(8197)
-    const AT_SEPRATOR = FOUR_PER_EM_SPACE
+    const AT_SEPRATOR = AT_SEPRATOR_REGEX
 
     const atList = this.text().split(AT_SEPRATOR)
     // console.log('atList: ', atList)


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Fix message.mention() bug on PC/Mac.

`AT_SEPERATOR` should be "\u0020"  if message is sent from PC/Mac, and "\u2005" from mobile:

<img width="385" alt="1" src="https://user-images.githubusercontent.com/2093721/49027081-58378c00-f1da-11e8-84b5-5f6d72f7ee33.png">

This bug is already mentioned here:

- https://github.com/Chatie/wechaty/issues/1511
- https://github.com/Chatie/wechaty/issues/1569


## Does this PR introduce a breaking change?

```
[ ] No
```

