### PR TITLE
Update link for wechaty-puppet-padchat

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ A `Bot` is a Wechaty instance that control a specific [wechaty-puppet](https://g
     2. `optoins.puppet?: string` select which puppet provider we want to use. must be one of the:
         1. [wechaty-puppet-puppeteer](https://github.com/chatie/wechaty-puppet-puppeteer) - Angular Hook for Web Wechat <- This is the DEFAULT
         2. [wechaty-puppet-wechat4u](https://github.com/chatie/wechaty-puppet-wechat4u) - HTTP API for Web Wechat
-        3. [wechaty-puppet-padchat](https://github.com/lijiarui/wechaty-puppet-padchat) - iPad App Protocol
+        3. [wechaty-puppet-padchat](https://github.com/botorange/wechaty-puppet-padpro) - iPad App Protocol
         4. [wechaty-puppet-ioscat](https://github.com/linyimin-bupt/wechaty-puppet-ioscat) - iPhone App Hook
         5. [wechaty-puppet-mock](https://github.com/chatie/wechaty-puppet-mock) - Mock for Testing
     3. `optoins.puppetOptions?: PuppetOptions` options for the puppet provider.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ A `Bot` is a Wechaty instance that control a specific [wechaty-puppet](https://g
     2. `optoins.puppet?: string` select which puppet provider we want to use. must be one of the:
         1. [wechaty-puppet-puppeteer](https://github.com/chatie/wechaty-puppet-puppeteer) - Angular Hook for Web Wechat <- This is the DEFAULT
         2. [wechaty-puppet-wechat4u](https://github.com/chatie/wechaty-puppet-wechat4u) - HTTP API for Web Wechat
-        3. [wechaty-puppet-padchat](https://github.com/botorange/wechaty-puppet-padpro) - iPad App Protocol
+        3. [wechaty-puppet-padpro](https://github.com/botorange/wechaty-puppet-padpro) - iPad App Protocol
         4. [wechaty-puppet-ioscat](https://github.com/linyimin-bupt/wechaty-puppet-ioscat) - iPhone App Hook
         5. [wechaty-puppet-mock](https://github.com/chatie/wechaty-puppet-mock) - Mock for Testing
     3. `optoins.puppetOptions?: PuppetOptions` options for the puppet provider.


### PR DESCRIPTION
## I'm submitting a...

- [ ] Bug Fix
- [ ] Feature
- [x] Other (Refactoring, Added tests, Documentation, ...)

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Correct a stale link.
[wechaty-puppet-padchat](https://github.com/lijiarui/wechaty-puppet-padchat) is no longer maintain. The new one is [wechaty-puppet-padpro](https://github.com/botorange/wechaty-puppet-padpro).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

