### PR TITLE
test: add escapeRegExp coverage

### DIFF
--- a/src/pure-functions/escape-regexp.spec.ts
+++ b/src/pure-functions/escape-regexp.spec.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/**
+ *   Wechaty Chatbot SDK - https://github.com/wechaty/wechaty
+ *
+ *   @copyright 2016 Huan LI (李卓桓) <https://github.com/huan>, and
+ *                   Wechaty Contributors <https://github.com/wechaty>.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+import { test } from 'tstest'
+
+import { escapeRegExp } from './escape-regexp.js'
+
+test('escapeRegExp() should keep plain strings unchanged', async t => {
+  t.equal(escapeRegExp('hello world'), 'hello world')
+  t.equal(escapeRegExp('Wechaty mention text'), 'Wechaty mention text')
+})
+
+test('escapeRegExp() should escape regex metacharacters', async t => {
+  const specialChars = '-/\\^$*+?.()|[]{}'
+
+  t.equal(
+    escapeRegExp(specialChars),
+    '\\-\\/\\\\\\^\\$\\*\\+\\?\\.\\(\\)\\|\\[\\]\\{\\}',
+  )
+})
+
+test('escapeRegExp() should escape mixed user-facing text', async t => {
+  t.equal(
+    escapeRegExp('hello (wechaty) [bot]? +1.0'),
+    'hello \\(wechaty\\) \\[bot\\]\\? \\+1\\.0',
+  )
+})


### PR DESCRIPTION
## Summary\n\nThis adds focused unit coverage for `escapeRegExp()`:\n\n- plain strings that should remain unchanged\n- regex metacharacters that should be escaped\n- mixed user-facing text with punctuation\n\nI kept the change intentionally small because this helper is used by message mention parsing and can regress silently.\n\n## Testing\n\n- `git diff --check` passed locally\n- Full test run not completed locally: dependency installation was blocked by registry connectivity from my environment (`pnpm install` could not fetch npm registry metadata). I am opening this as a draft so CI / maintainers can validate before review-ready status.