### PR TITLE
fix(ci): unblock main CI + restore type-test integrity (2.0.0-alpha.2)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-shellcheck@v1
       - name: Install Bats
         run: |
@@ -30,16 +30,16 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/v'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
           version: latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "sloc": "^0.2.1",
     "typed-emitter": "^1.5.0-from-event",
     "typedoc": "^1.0.0-dev.4 ",
+    "typescript": "~5.4.5",
     "wechaty-puppet-mock": "^1.18.2",
     "wechaty-puppet-padlocal": "^1.11.13"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/scripts/npm-pack-testing.sh
+++ b/scripts/npm-pack-testing.sh
@@ -24,7 +24,7 @@ cd $TMPDIR
 npm init -y
 npm install --production ./*-*.*.*.tgz \
   @types/node \
-  typescript@latest \
+  typescript@~5.4.5 \
   pkg-jq \
   file-box@"$NPM_TAG" \
   wechaty-puppet-mock@"$NPM_TAG" \

--- a/src/wechaty/wechaty-impl.spec.ts
+++ b/src/wechaty/wechaty-impl.spec.ts
@@ -100,7 +100,16 @@ test('Wechaty interface', async t => {
 })
 
 test('ProtectedProperties', async t => {
-  type NotExistInWechaty = Exclude<AllProtectedProperty, keyof WechatyImpl | `_${string}`>
+  /**
+   * Restrict the assertion to string-keyed properties. Symbol-keyed
+   * EventEmitter members (e.g. `captureRejectionSymbol`) cannot be reached
+   * through mixin-chain `keyof` inference, but Omit-ing them is a no-op
+   * anyway — they cannot be accidentally re-surfaced on `WechatyInterface`.
+   */
+  type NotExistInWechaty = Exclude<
+    Extract<AllProtectedProperty, string>,
+    keyof WechatyImpl | `_${string}`
+  >
   type NotExistTest = NotExistInWechaty extends never ? true : false
 
   const noOneLeft: NotExistTest = true


### PR DESCRIPTION
## Summary

\`main\` CI is currently fully red, blocking every PR against this repo. This is the minimal set of fixes needed to make it green again. **Zero behavior changes, zero business source changes** — only \`.github/workflows/\`, \`scripts/\`, one test type tweak, and a TypeScript devDep pin.

I'm happy to split into smaller PRs if preferred — bundled here for context.

## Why CI is red

Three independent layers of breakage stacked on top of each other (infra → config → source):

| Layer | Symptom | Root cause |
|-------|---------|-----------|
| ① | \`Node.js CI\` matrix: \`##[error]Cache service responded with 400\` from \`actions/setup-node@v2\` | GitHub is forcing Node-20 actions off; v2 uses a cache endpoint that now 400s |
| ② | \`Docker / Build\` + \`Build (22)\`: \`tsconfig.json(3,3): error TS5102: Option 'importsNotUsedAsValues' has been removed\` | No \`typescript\` pin in \`package.json\`, so \`npm install\` pulls TS 6.x, which hard-removed \`importsNotUsedAsValues\`. \`@chatie/tsconfig\` (every version, including 4.9.2) still uses it |
| ③ | (once ① and ② are unblocked) \`wechaty-impl.spec.ts(106,9): error TS2322: Type 'true' is not assignable to type 'false'\` | A protected-property type assertion that doesn't hold under modern \`@types/node\` |

## Fixes

### ① Bump deprecated GitHub Actions

\`.github/workflows/node.js.yml\`
- \`actions/checkout@v2\` → \`@v4\`
- \`actions/setup-node@v2\` → \`@v4\`

\`.github/workflows/docker.yml\`
- \`actions/checkout@v2\` → \`@v4\` (×2)
- \`docker/setup-qemu-action@v1\` → \`@v3\`
- \`docker/setup-buildx-action@v1\` → \`@v3\`

### ② Pin TypeScript to \`~5.4.5\`

\`package.json\`: add \`"typescript": "~5.4.5"\` to \`devDependencies\`.

TS 5.5+ hard-removed \`importsNotUsedAsValues\`. 5.4 is the last line that still accepts it, matching the intent of the existing \`ignoreDeprecations: "5.0"\` override in \`tsconfig.json\`.

A proper long-term fix belongs in \`@chatie/tsconfig\` — replace \`importsNotUsedAsValues\` with \`verbatimModuleSyntax\` (this repo's local tsconfig already sets \`verbatimModuleSyntax: false\` as a future-proof step).

Same pin propagated to \`scripts/npm-pack-testing.sh\` (smoke test installs \`typescript@latest\` into a fresh tmpdir, hits the same TS 6.x \`moduleResolution=node\` → \`node10\` deprecation as TS5107 with \`--noEmitOnError\`).

### ③ \`ProtectedProperties\` test: scope to string-keyed properties

\`src/wechaty/wechaty-impl.spec.ts\`

The test computes:

\`\`\`ts
type NotExistInWechaty = Exclude<AllProtectedProperty, keyof WechatyImpl | \`_\${string}\`>
type NotExistTest = NotExistInWechaty extends never ? true : false
const noOneLeft: NotExistTest = true
\`\`\`

To diagnose: temporarily forcing TS to name the orphan reveals it is **\`typeof captureRejectionSymbol\`** — the \`unique symbol\` exported from Node's \`events\` module. It's a member of \`keyof EventEmitter\` (because \`EventEmitter\` has a \`[captureRejectionSymbol]\` method), but the wechaty mixin chain (\`validationMixin\` → \`FP.pipe\` → \`WechatyImpl\`) preserves string-keyed instance members and loses symbol-keyed ones during inference. So the symbol key is not in \`keyof WechatyImpl\` and the \`Exclude\` leaves it as the residual orphan.

Symbol-keyed "protections" are semantically a no-op: \`Omit<T, K>\` where \`K\` is a \`unique symbol\` cannot accidentally re-surface a public method through the string-keyed \`WechatyInterface\` view. The string-keyed assertion is the only one that actually defends API surface.

Fix is minimal:

\`\`\`ts
type NotExistInWechaty = Exclude<
  Extract<AllProtectedProperty, string>,   // ← add Extract<..., string>
  keyof WechatyImpl | \`_\${string}\`
>
\`\`\`

This makes the contract honest about what it can actually guarantee, without weakening the string-keyed protection.

### Release: 2.0.0-alpha.2

Bumped \`package.json\` accordingly so a release can be cut from a green main.

## Files changed

| File | Change |
|------|--------|
| \`.github/workflows/node.js.yml\` | actions bump |
| \`.github/workflows/docker.yml\` | actions bump |
| \`package.json\` | add \`typescript\` pin + version 2.0.0-alpha.2 |
| \`scripts/npm-pack-testing.sh\` | pin \`typescript@~5.4.5\` |
| \`src/wechaty/wechaty-impl.spec.ts\` | scope ProtectedProperties test to string keys + comment |

**+22 / −9 across 5 files**, four commits.

## Verification

Full CI on my fork's matching branch is green across all jobs that exist here:

| Check | Result |
|-------|--------|
| Build (Docker) | ✅ pass |
| Build (22) | ✅ pass |
| build × (ubuntu / macOS / Windows) × Node 16 | ✅ pass |
| Pack (npm-pack-testing.sh smoke test) | ✅ pass |
| shellcheck | ✅ pass |

Run history: https://github.com/hcfw007/wechaty/pull/3

## Test plan

- [ ] Re-run upstream CI on this PR
- [ ] No regressions in \`dist/\` shape (only an unaffected change to dev pipeline)
- [ ] \`@chatie/tsconfig\` long-term modernization tracked separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipelines to use latest stable versions of build and deployment tools
  * Added TypeScript as a development dependency to ensure consistent build environments

* **Tests**
  * Refactored test type definitions with enhanced documentation for better maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wechaty/wechaty/pull/2830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->